### PR TITLE
build: add pgadmin container to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,15 @@ services:
       - "5432:5432"
     volumes:
       - db:/var/lib/postgresql/data
+  pgadmin:
+    image: dpage/pgadmin4:latest
+    restart: always
+    environment:
+      PGADMIN_DEFAULT_EMAIL: "admin@admin.com"
+      PGADMIN_DEFAULT_PASSWORD: "password"
+    ports:
+      - "5050:80"
+
 volumes:
   db:
     driver: local


### PR DESCRIPTION
I want to get a simple admin panel for the PostgreSQL database. I can now use the `pgadmin 6` container in the docker-compose config.